### PR TITLE
chore: update the tsup configuration to optimize the package bundle size

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -2,7 +2,7 @@ import type { Options } from 'tsup'
 
 export default <Options>{
   entryPoints: [
-    'src/*.ts',
+    'src/index.ts',
   ],
   clean: true,
   format: ['cjs', 'esm'],


### PR DESCRIPTION
Under watch mode:
	1. Reset the cache of emitted files
    2. Re-emit the files cached when re-build is triggered but the file remains unchanged

    In this situation, Vite won't resolve assets and this plugin wont't emit them,
	so they won't appear in the final output. We must trigger their emit manually.