### PR TITLE
Base assets from CSS off of the path for the CSS file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -265,6 +265,7 @@ export default function VitePluginLibAssets(options: Options = {}): Plugin {
         const assetsFromCss = await extractFromFile(this, id)
 
         const validAssets = assetsFromCss
+          .map(aid => path.resolve(path.dirname(id), aid))
           .filter(id => filter(id))
           .map(id => ({ id, content: getAssetContent(id) }))
           .filter(({ content }) => limit && content ? content.byteLength > limit : true)


### PR DESCRIPTION
Currently when a CSS file includes another CSS file from a subdirectory this plugin is unable to find the asset.

This causes Vite not to find the asset. This fixes the path so that Vite can find the assets.

Example:
```
lib
├── style.css
├── styles
    ├── fonts
    │   └── Helvetica
    │       └── helvetica.ttf
    └── globals.css
```

```
/* lib/style.css */
@import url(./styles/globals.css);
```
```
/* lib/styles/globals.css */
@font-face {
  font-family: 'Helvetica';
  font-style: normal;
  src: url('./fonts/Helvetica/helvetica.ttf') format('ttf');
}
```
Without this PR the above fails with: 
```
[vite-plugin-lib-assets]: file not found styles/fonts/Helvetica/helvetica.ttf
[commonjs--resolver] Could not set source for asset "assets/helvetica.[contenthash:8].ttf", asset source needs to be a string, Uint8Array or Buffer.
error during build:
RollupError: Could not set source for asset "assets/helvetica.[contenthash:8].ttf", asset source needs to be a string, Uint8Array or Buffer.
    at error (file://<dir>/node_modules/rollup/dist/es/shared/parseAst.js:337:30)
    at getValidSource (file://<dir>/node_modules/rollup/dist/es/shared/node-entry.js:18163:16)
    at FileEmitter.emitAsset (file://<dir>/node_modules/rollup/dist/es/shared/node-entry.js:18324:15)
    at FileEmitter.emitFile (file://<dir>/node_modules/rollup/dist/es/shared/node-entry.js:18203:25)
    at emitFile (file://<dir>/node_modules/@laynezh/vite-plugin-lib-assets/dist/index.js:387:15)
    at file://<dir>/node_modules/@laynezh/vite-plugin-lib-assets/dist/index.js:508:27
    at Array.forEach (<anonymous>)
    at Object.resolveId (file://<dir>/node_modules/@laynezh/vite-plugin-lib-assets/dist/index.js:507:21)
    at async PluginDriver.hookFirstAndGetPlugin (file://<dir>/node_modules/rollup/dist/es/shared/node-entry.js:18592:28)
    at async resolveId (file://<dir>/node_modules/rollup/dist/es/shared/node-entry.js:17261:26)
```
It is not taking into account that `globals.css` is inside `styles` folder, instead of being at the same level as `style.css`. This PR takes into account the dirname of the importing file and prefixes the assets path with it.

I haven't tried it with every possible combination of nested folders, but the above use case works great. Also I'm not sure of the purpose of `id` in the chain, maybe the fix shouldn't be implemented in the `.map()` like I did here, but rather adjust the argument to `getAssetContent(id)` as to leave the `id` the same as it is today. Please advise.