### PR TITLE
fix: remove unnecessary transform

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
   "dependencies": {
     "escape-string-regexp": "^4.0.0",
     "loader-utils": "^3.2.1",
-    "magic-string": "^0.30.7",
     "mrmime": "^1.0.1",
     "semver": "^7.6.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       loader-utils:
         specifier: ^3.2.1
         version: 3.2.1
-      magic-string:
-        specifier: ^0.30.7
-        version: 0.30.7
       mrmime:
         specifier: ^1.0.1
         version: 1.0.1
@@ -3245,6 +3242,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
 
   /mdast-util-from-markdown@0.8.5:
     resolution: {integrity: sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@ import type { Buffer } from 'node:buffer'
 import { type Alias, type Plugin, type ResolvedConfig, createFilter } from 'vite'
 import { type EmittedFile, type PluginContext } from 'rollup'
 import { interpolateName } from 'loader-utils'
-import MagicString from 'magic-string'
 import { checkFormats, getAssetContent, getCaptured, getFileBase64, replaceAll } from './utils'
 import { ASSETS_IMPORTER_RE, CSS_LANGS_RE, DEFAULT_ASSETS_RE, cssImageSetRE, cssUrlRE } from './constants'
 import { resolveCompiler } from './compiler'
@@ -229,9 +228,8 @@ export default function VitePluginLibAssets(options: Options = {}): Plugin {
     watchChange() {
       transformSkipped = true
     },
-    transform(code, id) {
+    transform() {
       transformSkipped = false
-      return { code, map: new MagicString(code).generateMap({ source: id }) }
     },
     configResolved(config) {
       viteConfig = config


### PR DESCRIPTION
Removes unnecessary transform. The `transform` hooks is not modifying anything so it can simply return `undefined`.