### PR TITLE
feat: support function type for limit option

### DIFF
--- a/README.ZH-CN.md
+++ b/README.ZH-CN.md
@@ -48,7 +48,7 @@ export interface Options {
   include?: string | RegExp | (string | RegExp)[]
   exclude?: string | RegExp | (string | RegExp)[]
   name?: string
-  limit?: number
+  limit?: number | ((filePath: string, content: Buffer) => boolean | undefined)
   outputPath?: string | ((url: string, resourcePath: string, resourceQuery: string) => string)
   regExp?: RegExp
   publicUrl?: string
@@ -99,14 +99,27 @@ export interface Options {
 
 低于 `limit` 设置体积的文件会以 base64 的格式內联到产物中
 
-- Type: `number`，单位 `Byte`
+- Type: `number | ((filePath: string, content: Buffer) => boolean | undefined)`
 - Default: `undefined`，表示所有文件都不会被内联
 - Example:
-  ```typescript
-  assetsLibPlugin({
-    limit: 1024 * 8 // 8KB
-  })
-  ```
+  - `number`（单位：`Byte`）
+    ```typescript
+    assetsLibPlugin({
+      limit: 1024 * 8 // 8KB
+    })
+    ```
+  - `function`
+    ```typescript
+    assetsLibPlugin({
+      limit: (filePath, content) => {
+        // 返回 `false` 会将文件内联为 base64
+        // 返回 `true` 或 `undefined` 会提取文件
+        if (filePath.endsWith('.json')) return true
+        // 小于 8KB 的文件会被内联
+        if (content.byteLength < 1024 * 8) return false
+      }
+    })
+    ```
 
 ### `outputPath`
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ export interface Options {
   include?: string | RegExp | (string | RegExp)[]
   exclude?: string | RegExp | (string | RegExp)[]
   name?: string
-  limit?: number
+  limit?: number | ((filePath: string, content: Buffer) => boolean | undefined)
   outputPath?: string | ((url: string, resourcePath: string, resourceQuery: string) => string)
   regExp?: RegExp
   publicUrl?: string
@@ -99,14 +99,27 @@ Output name of the resource file, its usage aligns with the [`name`](https://git
 
 Files larger than the `limit` will be extracted to the output directory, smaller files will remain embedded in the artifact in base64 format.
 
-- Type: `number`，unit `Byte`
+- Type: `number | ((filePath: string, content: Buffer) => boolean | undefined)`
 - Default: `undefined`，any size of resource files will be extracted
 - Example:
-  ```typescript
-  libAssetsPlugin({
-    limit: 1024 * 8 // 8KB
-  })
-  ```
+  - `number` (unit: `Byte`)
+    ```typescript
+    libAssetsPlugin({
+      limit: 1024 * 8 // 8KB
+    })
+    ```
+  - `function`
+    ```typescript
+    libAssetsPlugin({
+      limit: (filePath, content) => {
+        // Return `false` to inline the file as base64
+        // Return `true` or `undefined` to extract the file
+        if (filePath.endsWith('.json')) return true
+        // Files smaller than 8KB will be inlined
+        if (content.byteLength < 1024 * 8) return false
+      }
+    })
+    ```
 
 ### `outputPath`
 

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -39,6 +39,10 @@ export default defineConfig({
         /\.json(\?.*)?$/,
       ],
       name: '[name].[contenthash:8].[ext]',
+      limit: (filePath) => {
+        if (filePath.endsWith('.json'))
+          return true
+      },
     }),
   ],
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import type { Buffer } from 'node:buffer'
 import type * as _compiler from 'vue/compiler-sfc'
 
 export interface DescriptorOptions {
@@ -6,4 +7,20 @@ export interface DescriptorOptions {
     impl: typeof _compiler
     version: string
   }
+}
+
+type FuncOutputPath = (
+  url: string,
+  resourcePath: string,
+  resourceQuery: string
+) => string
+
+export interface Options {
+  include?: string | RegExp | (string | RegExp)[]
+  exclude?: string | RegExp | (string | RegExp)[]
+  name?: string
+  limit?: number | ((filePath: string, content: Buffer) => boolean | undefined)
+  outputPath?: string | FuncOutputPath
+  regExp?: RegExp
+  publicUrl?: string
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,7 @@ import { gte } from 'semver'
 import * as mrmime from 'mrmime'
 import escapeStringRegexp from 'escape-string-regexp'
 import { svgToDataURL } from './vitools'
+import type { Options } from './types'
 
 export function isObject(value: unknown): value is Record<string, any> {
   return Object.prototype.toString.call(value) === '[object Object]'
@@ -147,10 +148,33 @@ export function appendUrlQuery(url: string, kv: string): string {
  * @returns The URL without the key-value pair
  */
 export function removeUrlQuery(url: string, kv: string): string {
+  if (!url.includes('?'))
+    return url
   const [urlWithoutQuery, query = ''] = url.split('?')
   const queryParams = query.split('&')
   const filteredQueryParams = queryParams.filter(param => param !== kv)
   if (filteredQueryParams.length === 0)
     return urlWithoutQuery
   return `${urlWithoutQuery}?${filteredQueryParams.join('&')}`
+}
+
+/**
+ * Check if the asset should be processed based on the limit option
+ * @param id - The asset ID
+ * @param content - The asset content
+ * @param limit - The limit option
+ * @returns True if the asset should be processed, false otherwise
+ */
+export function shouldProcess(id: string, content: Buffer, limit: Options['limit']): boolean {
+  if (limit === undefined)
+    return true
+
+  if (typeof limit === 'function') {
+    if (limit(id, content!) === false)
+      return false
+  }
+  else if (content.byteLength < limit) {
+    return false
+  }
+  return true
 }


### PR DESCRIPTION
Allow `limit` option to accept a function similar to Vite's `assetsInlineLimit`, enabling custom asset processing logic based on file path and content.

- Add function type support: `(filePath: string, content: Buffer) => boolean | undefined`
- Add `shouldProcess` utility to handle both number and function limit types
- Update type definitions and documentation
- Add playground example

Closes #119